### PR TITLE
fix updating a meal with only unique name

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "nyc": {
     "exclude": [
       "**/index.js",
-			"**/app.js"
+      "**/app.js"
     ]
   },
   "config": {

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -9,7 +9,7 @@ module.exports = {
     host: process.env.DB_HOST,
     dialect: 'postgres',
     operatorAliases: Sequelize.Op,
-    logging: true,
+    logging: false,
     define: {
       underscored: true,
       underscoredAll: true,

--- a/server/controllers/MealController.js
+++ b/server/controllers/MealController.js
@@ -139,6 +139,8 @@ class MealController {
    */
   static async updateMeal(req, res) {
     const error = {};
+    const { validatedMeal } = req.body;
+
     // Find meal
     const matchedMeal = await Meal.findOne({
       where: { id: req.params.mealId },
@@ -154,13 +156,22 @@ class MealController {
     }
 
     // Update meal
-    const updatedMeal = await matchedMeal.update(req.body.validatedMeal);
+    try {
+      const updatedMeal = await matchedMeal.update(validatedMeal);
 
-    return res.status(200).json({
-      meal: updatedMeal,
-      status: 'success',
-      message: 'Sucessfully updated meal',
-    });
+      return res.status(200).json({
+        meal: updatedMeal,
+        status: 'success',
+        message: 'Sucessfully updated meal',
+      });
+    } catch (err) {
+      error.name = err.errors[0].message;
+      return res.status(409).json({
+        message: 'You cannot update meal name to an existing meal name',
+        status: 'error',
+        error,
+      });
+    }
   }
 
   /**

--- a/server/migrations/20180516162254-addUniqueConstraintToMealNameColumn.js
+++ b/server/migrations/20180516162254-addUniqueConstraintToMealNameColumn.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => (
+    queryInterface.addConstraint('meals', ['name'], {
+      type: 'unique',
+    })
+  ),
+
+  down: (queryInterface, Sequelize) => (
+    queryInterface.removeConstraint('meals', 'meals_name_uk')
+  ),
+};

--- a/server/models/Meal.js
+++ b/server/models/Meal.js
@@ -3,6 +3,7 @@ module.exports = (sequelize, DataTypes) => {
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+      unique: true,
     },
     description: {
       type: DataTypes.TEXT,

--- a/server/test/meals.spec.js
+++ b/server/test/meals.spec.js
@@ -282,6 +282,17 @@ describe('Meals', () => {
       expect(res.body.error.message).to
         .equal("Forbidden, you don't have the priviledge to perform this operation");
     });
+    it('should not update meal if meal name already exists', async () => {
+      const res = await chai.request(app).put(`${mealUrl}/1`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: meals[0].name,
+        });
+      expect(res.status).to.equal(409);
+      expect(res.body).to.be.an('object');
+      expect(res.body.error.name).to
+        .include('name must be unique');
+    });
   });
 
   // Test Delete a meal


### PR DESCRIPTION
#### What does this PR do?
Fix to update a meal with a meal name that already exists
#### Description of Task to be completed?
Meal name can only be updated with a name that doesn't exist in the database
#### How should this be manually tested?
Test the endpoint with postman
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories? (if applicable)
[Fix issue with updating a meal](https://www.pivotaltracker.com/story/show/157629599)