### PR TITLE
#159870895 Bug fixes for second cp defense

### DIFF
--- a/server/controllers/MealController.js
+++ b/server/controllers/MealController.js
@@ -63,6 +63,18 @@ class MealController {
     });
   }
 
+  /**
+   * @description - Get all meals for specific user
+   * @static
+   * @async
+   *
+   * @param {object} req HTTP Request
+   * @param {object} res HTTP Request
+   *
+   * @memberof MenuController
+   *
+   * @returns {Promise<JSON>}
+   */
   static async getUserMeals(req, res) {
     const userId = req.params.userId || req.userId;
     const limit = parseInt(req.query.limit, 10) || 30;
@@ -239,7 +251,9 @@ class MealController {
         where: { name, user_id: userId },
       });
 
-      if (foundMeal) {
+      // If the foundMeal with the name is a different meal
+      // then you cannot update this meal to that name because it already exist
+      if (foundMeal.id !== matchedMeal.id) {
         error.name = 'You cannot update meal name to an existing meal name';
         return res.status(409).json({
           message: error.name,

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -66,9 +66,9 @@ router.get(
   MealController.getAllMeals,
 );
 
-// Get orders for specific user
+// Get meal for specific caterer
 router.get(
-  '/v1/meals/users',
+  '/v1/meals/caterers',
   authenticate, authorize,
   queryValidator('limit'),
   queryValidator('page'),
@@ -76,8 +76,8 @@ router.get(
   MealController.getUserMeals,
 );
 router.get(
-  '/v1/meals/users/:userId',
-  authenticate, authorize,
+  '/v1/meals/caterers/:userId',
+  authenticate, authorizeSuperAdmin,
   idValidator('userId', 'User'),
   queryValidator('limit'),
   queryValidator('page'),
@@ -185,9 +185,41 @@ router.get(
   OrderController.getTotalAmount,
 );
 
+// Get Total amount made by specific caterer
+router.get(
+  '/v1/orders/totalAmount/caterers',
+  authenticate, authorize,
+  dateValidator(),
+  validationErrorHandler,
+  OrderController.getCatererTotalAmount,
+);
+router.get(
+  '/v1/orders/totalAmount/caterers/:userId',
+  authenticate, authorizeSuperAdmin,
+  dateValidator(),
+  validationErrorHandler,
+  OrderController.getCatererTotalAmount,
+);
+
 // Get Total number of orders made
 router.get(
   '/v1/orders/totalOrders',
+  authenticate, authorizeSuperAdmin,
+  dateValidator(),
+  validationErrorHandler,
+  OrderController.getTotalNumberOfOrders,
+);
+
+// Get Total number of meal orders made for specific caterer
+router.get(
+  '/v1/orders/totalOrders/caterers',
+  authenticate, authorize,
+  dateValidator(),
+  validationErrorHandler,
+  OrderController.getTotalNumberOfOrders,
+);
+router.get(
+  '/v1/orders/totalOrders/caterers/:userId',
   authenticate, authorizeSuperAdmin,
   dateValidator(),
   validationErrorHandler,
@@ -205,7 +237,8 @@ router.get(
 );
 router.get(
   '/v1/orders/users/:userId',
-  authenticate, idValidator('userId', 'User'),
+  authenticate, authorizeSuperAdmin,
+  idValidator('userId', 'User'),
   queryValidator('limit'),
   queryValidator('page'),
   validationErrorHandler,
@@ -223,7 +256,7 @@ router.get(
 );
 router.get(
   '/v1/orders/caterers/:userId',
-  authenticate, authorize,
+  authenticate, authorizeSuperAdmin,
   idValidator('userId', 'User'),
   queryValidator('limit'),
   queryValidator('page'),

--- a/server/test/meals.spec.js
+++ b/server/test/meals.spec.js
@@ -368,38 +368,46 @@ describe('Meals', () => {
     });
   });
 
-  // Test Get meals for specific user
+  // Test Get meals for specific caterer
   describe('Get meals for specific user(caterer)', () => {
-    it('should get meals for specific auth user with userId', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2`)
+    it('should get meals for specific auth signed in user(caterer)', async () => {
+      const res = await chai.request(app).get(`${mealUrl}/caterers`)
         .set('Authorization', `Bearer ${adminToken}`);
       expect(res.status).to.equal(200);
       expect(res.body.status).to.equal('success');
       expect(res.body.meals).to.be.an('array');
       expect(res.body.meals.length).to.equal(6);
     });
+    it('should get meals for specific auth user with userId', async () => {
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
+      expect(res.status).to.equal(200);
+      expect(res.body.status).to.equal('success');
+      expect(res.body.meals).to.be.an('array');
+      expect(res.body.meals.length).to.equal(6);
+    });
     it('should return error when no meals is found', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/10`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/10`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(404);
       expect(res.body.status).to.equal('error');
       expect(res.body.message).to.equal('No meals found!');
     });
     it('should return 4 meals if limit is set to 4', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?limit=4`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?limit=4`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(200);
       expect(res.body.meals.length).to.be.equal(4);
     });
     it('should return 2 meal from page three', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?limit=2&page=3`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?limit=2&page=3`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(200);
       expect(res.body.meals.length).to.be.equal(2);
     });
     it('should return links to traverse meals', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?limit=2`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?limit=2`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       const linkNames = res.body.links.map(link => link.rel);
       expect(res.status).to.equal(200);
       expect(linkNames.length).to.equal(3);
@@ -408,8 +416,8 @@ describe('Meals', () => {
       expect(linkNames).to.include('self');
     });
     it('should return link to first page', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?limit=2&page=2`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?limit=2&page=2`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       const linkNames = res.body.links.map(link => link.rel);
       expect(res.status).to.equal(200);
       expect(res.body.meals.length).to.equal(2);
@@ -417,43 +425,43 @@ describe('Meals', () => {
       expect(linkNames.length).to.equal(5);
     });
     it('should return an error if limit is less than zero', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?limit=-10`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?limit=-10`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(400);
       expect(res.body.status).to.equal('error');
       expect(res.body.error.limit).to.equal('limit cannot be less than zero');
     });
     it('should return an error if limit is a fractional number', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?limit=9.5`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?limit=9.5`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(400);
       expect(res.body.status).to.equal('error');
       expect(res.body.error.limit).to.equal('limit must be a whole number');
     });
     it('should return an error if limit is not a number', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?limit=b`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?limit=b`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(400);
       expect(res.body.status).to.equal('error');
       expect(res.body.error.limit).to.equal('limit must be a number');
     });
     it('should return an error if page is less than zero', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?page=-10`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?page=-10`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(400);
       expect(res.body.status).to.equal('error');
       expect(res.body.error.page).to.equal('page cannot be less than zero');
     });
     it('should return an error if page is a fractional number', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?page=9.5`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?page=9.5`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(400);
       expect(res.body.status).to.equal('error');
       expect(res.body.error.page).to.equal('page must be a whole number');
     });
     it('should return an error if page is not a number', async () => {
-      const res = await chai.request(app).get(`${mealUrl}/users/2?page=b`)
-        .set('Authorization', `Bearer ${adminToken}`);
+      const res = await chai.request(app).get(`${mealUrl}/caterers/2?page=b`)
+        .set('Authorization', `Bearer ${superAdminToken}`);
       expect(res.status).to.equal(400);
       expect(res.body.status).to.equal('error');
       expect(res.body.error.page).to.equal('page must be a number');
@@ -515,6 +523,15 @@ describe('Meals', () => {
       expect(res.status).to.equal(409);
       expect(res.body.error.name).to
         .equal('You cannot update meal name to an existing meal name');
+    });
+    it('should update meal to its current meal name', async () => {
+      const res = await chai.request(app).put(`${mealUrl}/13`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Semo and Abang soup',
+        });
+      expect(res.status).to.equal(200);
+      expect(res.body.meal.name).to.equal('Semo and Abang soup');
     });
     it('should not update meal with price that is less than zero', async () => {
       const res = await chai.request(app).put(`${mealUrl}/1`)


### PR DESCRIPTION
#### What does this PR do?
Bug fixes for second cp defense
#### Description of Task to be completed?
- Make meal name only unique when the meal name belongs to another meal,
that is the unique constraint on a meal name should only apply
when the meal updating is a different meal updating its name to another
meal name
- Identify userId for user orders and meals based on their signed in token.
Only superAdmins should be able to retrieve meals or orders
for a particular user using their userId
- Add routes for retrieving total amount made and total number of orders
for specific caterer
#### How should this be manually tested?
N/A
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
#159870895